### PR TITLE
Specify RH hosted Llama Stack image

### DIFF
--- a/docs/kfp-pipelines/docling_rag/docling_convert_pipeline.py
+++ b/docs/kfp-pipelines/docling_rag/docling_convert_pipeline.py
@@ -31,7 +31,7 @@ def register_vector_db(
     client = LlamaStackClient(base_url=service_url)
 
     models = client.models.list()
-    matching_model = next((m for m in models if m.identifier == embed_model_id), None)
+    matching_model = next((m for m in models if m.provider_resource_id == embed_model_id), None)
 
     if not matching_model:
         raise ValueError(f"Model with ID '{embed_model_id}' not found on LlamaStack server.")
@@ -44,7 +44,7 @@ def register_vector_db(
     # Register the vector DB
     _ = client.vector_dbs.register(
         vector_db_id=vector_db_id,
-        embedding_model=embed_model_id,
+        embedding_model=matching_model.identifier,
         embedding_dimension=embedding_dimension,
         provider_id="milvus",
     )
@@ -224,7 +224,7 @@ def docling_convert_pipeline(
     pdf_filenames: str = "2203.01017v2.pdf, 2206.01062.pdf, 2305.03393v1-pg9.pdf, amt_handbook_sample.pdf, code_and_formula.pdf, multi_page.pdf, picture_classification.pdf, redp5110_sampled.pdf, right_to_left_01.pdf, right_to_left_02.pdf, right_to_left_03.pdf",
     num_workers: int = 1,
     vector_db_id: str = "my_demo_vector_id",
-    service_url: str = "http://llama-test-milvus-kserve-service:8321",
+    service_url: str = "http://lsd-llama-milvus-service:8321",
     embed_model_id: str = "ibm-granite/granite-embedding-125m-english",
     max_tokens: int = 512,
     use_gpu: bool = True,

--- a/docs/kfp-pipelines/docling_rag/docling_convert_pipeline_compiled.yaml
+++ b/docs/kfp-pipelines/docling_rag/docling_convert_pipeline_compiled.yaml
@@ -7,7 +7,7 @@
 #    max_tokens: int [Default: 512.0]
 #    num_workers: int [Default: 1.0]
 #    pdf_filenames: str [Default: '2203.01017v2.pdf, 2206.01062.pdf, 2305.03393v1-pg9.pdf, amt_handbook_sample.pdf, code_and_formula.pdf, multi_page.pdf, picture_classification.pdf, redp5110_sampled.pdf, right_to_left_01.pdf, right_to_left_02.pdf, right_to_left_03.pdf']
-#    service_url: str [Default: 'http://llama-test-milvus-kserve-service:8321']
+#    service_url: str [Default: 'http://lsd-llama-milvus-service:8321']
 #    use_gpu: bool [Default: True]
 #    vector_db_id: str [Default: 'my_demo_vector_id']
 components:
@@ -610,13 +610,13 @@ deploymentSpec:
           \ str,\n    embed_model_id: str,\n):\n    from llama_stack_client import\
           \ LlamaStackClient\n\n    client = LlamaStackClient(base_url=service_url)\n\
           \n    models = client.models.list()\n    matching_model = next((m for m\
-          \ in models if m.identifier == embed_model_id), None)\n\n    if not matching_model:\n\
-          \        raise ValueError(f\"Model with ID '{embed_model_id}' not found\
-          \ on LlamaStack server.\")\n\n    if matching_model.model_type != \"embedding\"\
-          :\n        raise ValueError(f\"Model '{embed_model_id}' is not an embedding\
-          \ model\")\n\n    embedding_dimension = matching_model.metadata[\"embedding_dimension\"\
-          ]\n\n    # Register the vector DB\n    _ = client.vector_dbs.register(\n\
-          \        vector_db_id=vector_db_id,\n        embedding_model=embed_model_id,\n\
+          \ in models if m.provider_resource_id == embed_model_id), None)\n\n    if\
+          \ not matching_model:\n        raise ValueError(f\"Model with ID '{embed_model_id}'\
+          \ not found on LlamaStack server.\")\n\n    if matching_model.model_type\
+          \ != \"embedding\":\n        raise ValueError(f\"Model '{embed_model_id}'\
+          \ is not an embedding model\")\n\n    embedding_dimension = matching_model.metadata[\"\
+          embedding_dimension\"]\n\n    # Register the vector DB\n    _ = client.vector_dbs.register(\n\
+          \        vector_db_id=vector_db_id,\n        embedding_model=matching_model.identifier,\n\
           \        embedding_dimension=embedding_dimension,\n        provider_id=\"\
           milvus\",\n    )\n    print(f\"Registered vector DB '{vector_db_id}' with\
           \ embedding model '{embed_model_id}'.\")\n\n"
@@ -736,7 +736,7 @@ root:
         isOptional: true
         parameterType: STRING
       service_url:
-        defaultValue: http://llama-test-milvus-kserve-service:8321
+        defaultValue: http://lsd-llama-milvus-service:8321
         description: URL of the Milvus service
         isOptional: true
         parameterType: STRING

--- a/stack/base/llama-stack-distribution.yaml
+++ b/stack/base/llama-stack-distribution.yaml
@@ -13,11 +13,13 @@ spec:
       - name: VLLM_URL
         value: http://vllm-predictor/v1
       - name: MILVUS_DB_PATH
-        value: "/.llama/distributions/remote-vllm/milvus.db"
+        value: ~/.llama/milvus.db
+      - name: FMS_ORCHESTRATOR_URL
+        value: 'http://localhost'
       name: llama-stack
       port: 8321
     distribution:
-      image: quay.io/mcampbel/llama-stack:milvus-granite-embedding-125m-english
+      image: quay.io/opendatahub/llama-stack:odh
     podOverrides:
       volumeMounts:
       - mountPath: "/root/.llama"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
llama stack upstream server requires all the provider requirements to be set before starting
so for the `FMS_ORCHESTRATOR_URL` we would need to set up trustyai_fms guardrails, not sure if we would want that for the RAG? At the moment we can specify anything and it will keep working. I was told there is plans with upstream to have some graceful failure, but no other workaround for 2.22 Dev Preview

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work