### PR TITLE
build: update milvus.db path

### DIFF
--- a/stack/overlays/vllm-remote-inference-model/llama-stack-distribution.yaml
+++ b/stack/overlays/vllm-remote-inference-model/llama-stack-distribution.yaml
@@ -40,7 +40,7 @@ spec:
               name: llama-stack-inference-model-secret
               optional: true
         - name: MILVUS_DB_PATH
-          value: ~/.llama/milvus.db
+          value: ~/.llama/distributions/rh/milvus.db
         - name: FMS_ORCHESTRATOR_URL
           value: "http://localhost"
       name: llama-stack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since the latest updates to the Llama Stack ODH image the current path for the milvus.db file will not work.
This PR updates the path to instead be within the Red Hat distribution's folder.

I was getting permission errors for creating the file in `~/.llama`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run through the [remote inference setup](https://github.com/opendatahub-io/rag/blob/main/DEPLOYMENT.md#option-d-setup-using-an-inference-model-deployed-remotely)
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the default Milvus database storage path used by remote inference deployments via the MILVUS_DB_PATH environment variable.
  - New installations will use the new directory automatically.
  - Existing setups that relied on the previous default path may need to adjust configuration or migrate data to the new location.
  - No functional changes to inference behavior; this is a configuration path update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->